### PR TITLE
Simple fix of BrokenPipeError

### DIFF
--- a/pymystem3/mystem.py
+++ b/pymystem3/mystem.py
@@ -261,7 +261,12 @@ class Mystem(object):
 
         result = []
         for line in text.splitlines():
-            result.extend(self._analyze_impl(line))
+            try:
+                result.extend(self._analyze_impl(line))
+            except BrokenPipeError:
+                self.close()
+                self.start()
+                result.extend(self._analyze_impl(line))
         return result
 
     def lemmatize(self, text):


### PR DESCRIPTION
fixes #21 

I simply wrapped _analyze_impl with try-error. Maybe it would be smarter to go deeper in _analyze_impl but let's consider this fix to be an easier to read alternative)