### PR TITLE
Added use_english_names param (--eng-gr option)

### DIFF
--- a/pymystem3/mystem.py
+++ b/pymystem3/mystem.py
@@ -166,6 +166,8 @@ class Mystem(object):
     :type   generate_all: bool
     :param  fixlist: path to a custom dictionary to use for analysis
     :type   fixlist: str
+    :param  use_english_names: english names of grammemes
+    :type   use_english_names: bool
 
     .. note:: Default value of :py:attr:`mystem_bin` can be overwritted by :envvar:`MYSTEM_BIN`.
     """
@@ -178,7 +180,8 @@ class Mystem(object):
         entire_input=True,
         weight=True,
         generate_all=False,
-        fixlist=None
+        fixlist=None,
+        use_english_names=False
     ):
         self._mystem_bin = mystem_bin
         self._grammar_info = grammar_info
@@ -187,6 +190,7 @@ class Mystem(object):
         self._weight = weight
         self._generate_all = generate_all
         self._fixlist = fixlist
+        self._use_english_names = use_english_names
         self._procin = None
         self._procout = None
         self._procout_no = None
@@ -219,6 +223,9 @@ class Mystem(object):
         if self._fixlist is not None:
             self._mystemargs.append('--fixlist')
             self._mystemargs.append(self._fixlist)
+            
+        if self._use_english_names is True:
+            self._mystemargs.append('--eng-gr')
 
     def __del__(self):
         self.close()  # terminate process on exit


### PR DESCRIPTION
Sometimes english names of grammar characteristics needed. 